### PR TITLE
Tokenize: fix NoneType error and filter whitespace before regex split

### DIFF
--- a/memorynetwork.py
+++ b/memorynetwork.py
@@ -28,7 +28,7 @@ def tokenize(sent):
     >>> tokenize('Bob dropped the apple. Where is the apple?')
     ['Bob', 'dropped', 'the', 'apple', '.', 'Where', 'is', 'the', 'apple', '?']
     '''
-    return [x.strip() for x in re.split('(\W+)?', sent) if x.strip()]
+    return [x.strip() for x in re.split('(\w+)?', sent) if x and not x.isspace()]
 
 
 def parse_stories(lines, only_supporting=False):


### PR DESCRIPTION
The result of the tokenize function is not as expected. The regex and conditionals were readjusted.